### PR TITLE
Add static class with helper methods

### DIFF
--- a/Clowd.Clipboard/Clipboard.cs
+++ b/Clowd.Clipboard/Clipboard.cs
@@ -18,9 +18,7 @@ namespace Clowd.Clipboard
         }
 
         /// <summary>
-        /// Clears everything on the clipboard. This is also done automatically before
-        /// setting any data to the clipboard, so it does not need to be called explicitly
-        /// unless you wish to completely empty the clipboard and leave it that way.
+        /// <inheritdoc cref="ClipboardHandle.Empty"/>
         /// </summary>
         public static void Empty()
         {
@@ -29,7 +27,7 @@ namespace Clowd.Clipboard
         }
 
         /// <summary>
-        /// Retrieves any text stored on the clipboard.
+        /// <inheritdoc cref="ClipboardHandle.GetText"/>
         /// </summary>
         public static string GetText()
         {
@@ -38,7 +36,7 @@ namespace Clowd.Clipboard
         }
 
         /// <summary>
-        /// Sets the text on the clipboard to the specified string.
+        /// <inheritdoc cref="ClipboardHandle.SetText"/>
         /// </summary>
         public static void SetText(string text)
         {
@@ -47,7 +45,7 @@ namespace Clowd.Clipboard
         }
 
         /// <summary>
-        /// Sets the image on the clipboard to the specified bitmap.
+        /// <inheritdoc cref="ClipboardHandle.SetImage"/>
         /// </summary>
         public static void SetImage(BitmapSource bitmap)
         {
@@ -56,7 +54,7 @@ namespace Clowd.Clipboard
         }
 
         /// <summary>
-        /// Retrieves any detectable bitmap stored on the clipboard.
+        /// <inheritdoc cref="ClipboardHandle.GetImage"/>
         /// </summary>
         public static BitmapSource GetImage()
         {
@@ -65,7 +63,7 @@ namespace Clowd.Clipboard
         }
 
         /// <summary>
-        /// Retrieves the current file drop list on the clipboard, or returns null if there is none.
+        /// <inheritdoc cref="ClipboardHandle.GetFileDropList"/>
         /// </summary>
         public static string[] GetFileDropList()
         {
@@ -74,7 +72,7 @@ namespace Clowd.Clipboard
         }
 
         /// <summary>
-        /// Set the file drop list on the clipboard to the specified list of strings.
+        /// <inheritdoc cref="ClipboardHandle.SetFileDropList"/>
         /// </summary>
         public static void SetFileDropList(string[] files)
         {

--- a/Clowd.Clipboard/Clipboard.cs
+++ b/Clowd.Clipboard/Clipboard.cs
@@ -1,0 +1,85 @@
+﻿using System.Windows.Media.Imaging;
+
+namespace Clowd.Clipboard
+{
+    /// <summary>
+    /// Provides static methods for easy access to some of the most basic functionality of <see cref="ClipboardHandle"/>.
+    /// </summary>
+    public static class Clipboard
+    {
+        /// <summary>
+        /// Opens a clipboard handle and returns it. You are responsible for disposing of it when done.
+        /// </summary>
+        public static ClipboardHandle Open()
+        {
+            var ch = new ClipboardHandle();
+            ch.Open();
+            return ch;
+        }
+
+        /// <summary>
+        /// Clears everything on the clipboard. This is also done automatically before
+        /// setting any data to the clipboard, so it does not need to be called explicitly
+        /// unless you wish to completely empty the clipboard and leave it that way.
+        /// </summary>
+        public static void Empty()
+        {
+            using var ch = Open();
+            ch.Empty();
+        }
+
+        /// <summary>
+        /// Retrieves any text stored on the clipboard.
+        /// </summary>
+        public static string GetText()
+        {
+            using var ch = Open();
+            return ch.GetText();
+        }
+
+        /// <summary>
+        /// Sets the text on the clipboard to the specified string.
+        /// </summary>
+        public static void SetText(string text)
+        {
+            using var ch = Open();
+            ch.SetText(text);
+        }
+
+        /// <summary>
+        /// Sets the image on the clipboard to the specified bitmap.
+        /// </summary>
+        public static void SetImage(BitmapSource bitmap)
+        {
+            using var ch = Open();
+            ch.SetImage(bitmap);
+        }
+
+        /// <summary>
+        /// Retrieves any detectable bitmap stored on the clipboard.
+        /// </summary>
+        public static BitmapSource GetImage()
+        {
+            using var ch = Open();
+            return ch.GetImage();
+        }
+
+        /// <summary>
+        /// Retrieves the current file drop list on the clipboard, or returns null if there is none.
+        /// </summary>
+        public static string[] GetFileDropList()
+        {
+            using var ch = Open();
+            return ch.GetFileDropList();
+        }
+
+        /// <summary>
+        /// Set the file drop list on the clipboard to the specified list of strings.
+        /// </summary>
+        public static void SetFileDropList(string[] files)
+        {
+            using var ch = Open();
+            ch.SetFileDropList(files);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `Clipboard` static class with the following methods:

* `Open()` — instantiates and opens a handle and returns it.
* `GetText/Image/etc.(), SetText/Image/etc.()` — opens a handle, does the requested action, and disposes immediately.